### PR TITLE
Dra 2202 refactor `CustomJacksonJsonProvider.class` into `ds-shared`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+target/
+.classpath
+.project
+.settings/
+
+# We use pom.xml as the source of truth and don't rely on a specific IDE
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -13,4 +13,16 @@
     <artifactId>ds-shared</artifactId>
     <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>dk.kb.util</groupId>
+            <artifactId>kb-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/dk/kb/shared/webservice/CustomJacksonJsonProvider.java
+++ b/src/main/java/dk/kb/shared/webservice/CustomJacksonJsonProvider.java
@@ -1,0 +1,29 @@
+package dk.kb.shared.webservice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public final class CustomJacksonJsonProvider extends JacksonJsonProvider {
+
+    /**
+     * We add our own JacksonJsonProvider to register Java Time 8
+     * And we disable WRITE_DATES_AS_TIMESTAMPS so Jackson serialize Java Time in standard ISO-8601 string representation
+     * https://fasterxml.github.io/jackson-modules-java8/javadoc/datetime/2.9/com/fasterxml/jackson/datatype/jsr310/JavaTimeModule.html
+     */
+    public CustomJacksonJsonProvider() {
+        super();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        setMapper(objectMapper);
+    }
+}
+


### PR DESCRIPTION
`CustomJacksonJsonProvider.class` was used i `ds-datahandler` and `ds-license` so refactor it into `ds-shared`.